### PR TITLE
Support for background grid pattern

### DIFF
--- a/src/xml/nord.xml
+++ b/src/xml/nord.xml
@@ -39,6 +39,7 @@ References:
 <!--+- - - - - +
     + Settings +
     +- - - - - +-->
+  <style name="background-pattern" background="nord1"/>
   <style name="bracket-match" foreground="nord4" background="nord10"/>
   <style name="bracket-mismatch" foreground="nord11" underline="true" />
   <style name="current-line" foreground="nord4" background="nord1" />


### PR DESCRIPTION
> Resolves #9

This PR adds highlighting support for the background grid pattern which can be enabled by users through the preferences.

![gh-9-preview](https://user-images.githubusercontent.com/7836623/41820642-60fbf260-77d5-11e8-95fb-c7e41c6a9832.png)
