### PR TITLE
make def:note more visible

### DIFF
--- a/src/xml/nord.xml
+++ b/src/xml/nord.xml
@@ -85,7 +85,7 @@ References:
   <style name="def:doc-comment" use-style="def:comment" />
   <style name="def:doc-comment-element" foreground="nord9" />
   <style name="def:net-address-in-comment" foreground="nord3-brightened" underline="true" />
-  <style name="def:note" use-style="def:comment" />
+  <style name="def:note" foreground="nord13" bold="true" />
 
   <!--+- Keywords -+-->
   <style name="def:class" foreground="nord7" />


### PR DESCRIPTION
Before and after:

![gedit-nord-diff](https://user-images.githubusercontent.com/56464409/178156056-c6436cde-1a90-4209-9458-b382bf96d6f3.png)
